### PR TITLE
LdProvider has client prop as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ld",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Connects a Launch Darkly client with a react tree",
   "main": "lib/index.js",
   "repository": "git@github.com:Tabcorp/react-ld.git",

--- a/src/LdProvider.js
+++ b/src/LdProvider.js
@@ -12,7 +12,7 @@ type SettingsT = {|
 
 type Props = {|
   children?: React.Node,
-  client: {
+  client?: {
     on: (string, Function) => void,
     allFlags: () => FlagsT,
     ...
@@ -28,6 +28,8 @@ const LdProvider = ({
   const [flags, setFlags] = React.useState<FlagsT | void>();
 
   React.useEffect(() => {
+    if (!client) return () => {};
+
     const mapToCurrentFlags = (
       settings: SettingsT,
     ) => (
@@ -59,7 +61,7 @@ const LdProvider = ({
     return () => {
       clearInterval(readyInterval);
     };
-  }, []);
+  }, [client]);
 
   if (!flags && !async) return null;
 

--- a/src/LdProvider.spec.js
+++ b/src/LdProvider.spec.js
@@ -120,4 +120,20 @@ describe('useLdFlag', () => {
     expect(container.textContent).toBe('loaded');
     jest.advanceTimersByTime(1);
   });
+
+  it('does not try to get flags if no client is provided', () => {
+    const originalSetInterval = window.setInterval;
+    window.setInterval = jest.fn();
+    const { container } = render(
+      <LdProvider>
+        <div>
+          loaded
+        </div>
+      </LdProvider>,
+    );
+
+    expect(container.textContent).toBe('');
+    expect(window.setInterval).not.toHaveBeenCalled();
+    window.setInterval = originalSetInterval;
+  });
 });


### PR DESCRIPTION
## Summary
Make the LdProvider more user friendly by allowing the client to be optional. So that if a consumer forgets to pass it in, it doesn't throw errors.

<!--
**I acknowledge that any breaking changes will be highlighted in the following way**
```
- [BREAKING] Some fix I am making
```
-->

## Changed
- `LdProvider` client prop is now optional