### PR TITLE
use waitForInitialization instead of setInterval which is more stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ld",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Connects a Launch Darkly client with a react tree",
   "main": "lib/index.js",
   "repository": "git@github.com:Tabcorp/react-ld.git",

--- a/src/LdFeature.spec.js
+++ b/src/LdFeature.spec.js
@@ -1,16 +1,15 @@
 // @flow
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 import {
   LdProvider,
   LdFeature,
 } from '.';
 
-jest.useFakeTimers();
-
 describe('<LdFeature', () => {
-  it('renders the feature only when true', () => {
+  it('renders the feature only when true', (done) => {
+    const hook = jest.fn();
     const fakeClient = {
       on: (key, callback) => {
         if (key === 'ready') {
@@ -19,6 +18,10 @@ describe('<LdFeature', () => {
       },
       allFlags: jest.fn(() => ({
         enableTest: true,
+      })),
+      waitForInitialization: jest.fn(() => new Promise((resolve) => {
+        resolve();
+        hook();
       })),
     };
     const App = () => (
@@ -45,12 +48,14 @@ describe('<LdFeature', () => {
       </LdProvider>,
     );
 
-    jest.advanceTimersByTime(1000);
-
-    expect(getByTestId('element').textContent).toBe('enabled feature');
+    waitFor(() => expect(hook).toHaveBeenCalled()).then(() => {
+      expect(getByTestId('element').textContent).toBe('enabled feature');
+      done();
+    });
   });
 
-  it('renders the feature if false and deprecation is true', () => {
+  it('renders the feature if false and deprecation is true', (done) => {
+    const hook = jest.fn();
     const fakeClient = {
       on: (key, callback) => {
         if (key === 'ready') {
@@ -60,6 +65,10 @@ describe('<LdFeature', () => {
       allFlags: jest.fn(() => ({
         enableTest: false,
       })),
+      waitForInitialization: jest.fn(() => new Promise((resolve) => {
+        resolve();
+        hook();
+      })),
     };
     const App = () => (
       <div data-testid="element">
@@ -79,18 +88,19 @@ describe('<LdFeature', () => {
     const { getByTestId } = render(
       <LdProvider
         client={fakeClient}
-        async
       >
         <App />
       </LdProvider>,
     );
 
-    jest.advanceTimersByTime(1000);
-
-    expect(getByTestId('element').textContent).toBe('disabled feature');
+    waitFor(() => expect(hook).toHaveBeenCalled()).then(() => {
+      expect(getByTestId('element').textContent).toBe('disabled feature');
+      done();
+    });
   });
 
-  it('does not render the feature when feature is true and deprecation is true', () => {
+  it('does not render the feature when feature is true and deprecation is true', (done) => {
+    const hook = jest.fn();
     const fakeClient = {
       on: (key, callback) => {
         if (key === 'ready') {
@@ -99,6 +109,10 @@ describe('<LdFeature', () => {
       },
       allFlags: jest.fn(() => ({
         enableTest: true,
+      })),
+      waitForInitialization: jest.fn(() => new Promise((resolve) => {
+        resolve();
+        hook();
       })),
     };
     const App = () => (
@@ -120,7 +134,10 @@ describe('<LdFeature', () => {
       </LdProvider>,
     );
 
-    expect(getByTestId('element').textContent).toBe('');
+    waitFor(() => expect(hook).toHaveBeenCalled()).then(() => {
+      expect(getByTestId('element').textContent).toBe('');
+      done();
+    });
   });
 
   it('accepts not passing child', () => {
@@ -133,6 +150,7 @@ describe('<LdFeature', () => {
       allFlags: jest.fn(() => ({
         enableTest: true,
       })),
+      waitForInitialization: jest.fn(() => Promise.resolve()),
     };
     const App = () => (
       <div data-testid="element">

--- a/src/LdProvider.spec.js
+++ b/src/LdProvider.spec.js
@@ -7,13 +7,16 @@ import {
   useLdFlag,
 } from '.';
 
-jest.useFakeTimers();
-
 describe('useLdFlag', () => {
   it('renders nothing before loading', () => {
+    const hook = jest.fn();
     const fakeClient = {
       on: () => {},
       allFlags: jest.fn(() => ({ test: true })),
+      waitForInitialization: jest.fn(() => new Promise((resolve) => {
+        resolve();
+        hook();
+      })),
     };
 
     const { queryByTestId } = render(
@@ -31,6 +34,7 @@ describe('useLdFlag', () => {
     const fakeClient = {
       on: () => {},
       allFlags: jest.fn(() => ({ test: true })),
+      waitForInitialization: jest.fn(() => Promise.resolve()),
     };
 
     const { getByTestId } = render(
@@ -57,6 +61,7 @@ describe('useLdFlag', () => {
         }
       },
       allFlags: jest.fn(() => ({ test: true })),
+      waitForInitialization: jest.fn(() => Promise.resolve()),
     };
 
     const App = () => {
@@ -72,7 +77,6 @@ describe('useLdFlag', () => {
     const { getByTestId } = render(
       <LdProvider
         client={fakeClient}
-        async
       >
         <App />
       </LdProvider>,
@@ -85,6 +89,7 @@ describe('useLdFlag', () => {
     const fakeClient = {
       on: () => {},
       allFlags: jest.fn(() => ({ test: true })),
+      waitForInitialization: jest.fn(() => Promise.resolve()),
     };
 
     const { container } = render(
@@ -96,34 +101,7 @@ describe('useLdFlag', () => {
     expect(container.textContent).toBe('');
   });
 
-  it('will keep waiting until flags are returned', () => {
-    const fakeClient = {
-      on: () => {},
-      allFlags: jest.fn(),
-    };
-    fakeClient.allFlags
-      .mockReturnValueOnce({})
-      .mockReturnValueOnce({ test: true });
-
-    const { container } = render(
-      <LdProvider
-        client={fakeClient}
-      >
-        <div>
-          loaded
-        </div>
-      </LdProvider>,
-    );
-
-    expect(container.textContent).toBe('');
-    jest.advanceTimersByTime(1);
-    expect(container.textContent).toBe('loaded');
-    jest.advanceTimersByTime(1);
-  });
-
   it('does not try to get flags if no client is provided', () => {
-    const originalSetInterval = window.setInterval;
-    window.setInterval = jest.fn();
     const { container } = render(
       <LdProvider>
         <div>
@@ -133,7 +111,5 @@ describe('useLdFlag', () => {
     );
 
     expect(container.textContent).toBe('');
-    expect(window.setInterval).not.toHaveBeenCalled();
-    window.setInterval = originalSetInterval;
   });
 });


### PR DESCRIPTION
## Summary
Implement initial setter of flags to use `waitForInitialization` which is more stable and overall does the required job

<!--
**I acknowledge that any breaking changes will be highlighted in the following way**
```
- [BREAKING] Some fix I am making
```
-->

## Changed
- Use `waitForInitialization` instead of `setInterval` to pull initial flags
