### PR TITLE
Publish lib under commonjs format

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,9 @@ const config = {
     '@babel/preset-react',
     '@babel/preset-flow',
   ],
+  plugins: [
+    '@babel/plugin-transform-modules-commonjs',
+  ],
 };
 
 if (process.env.NODE_ENV !== 'test') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ld",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Connects a Launch Darkly client with a react tree",
   "main": "lib/index.js",
   "repository": "git@github.com:Tabcorp/react-ld.git",
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@babel/cli": "7.8.4",
     "@babel/core": "7.9.6",
+    "@babel/plugin-transform-modules-commonjs": "^7.10.4",
     "@babel/preset-env": "7.9.6",
     "@babel/preset-flow": "7.9.0",
     "@babel/preset-react": "^7.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -247,7 +247,7 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-module-transforms@^7.11.0":
+"@babel/helper-module-transforms@^7.10.4", "@babel/helper-module-transforms@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz#b16f250229e47211abdd84b34b64737c2ab2d359"
   integrity sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==
@@ -736,6 +736,16 @@
   dependencies:
     "@babel/helper-module-transforms" "^7.9.0"
     "@babel/helper-plugin-utils" "^7.8.3"
+    babel-plugin-dynamic-import-node "^2.3.3"
+
+"@babel/plugin-transform-modules-commonjs@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz#66667c3eeda1ebf7896d41f1f16b17105a2fbca0"
+  integrity sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-simple-access" "^7.10.4"
     babel-plugin-dynamic-import-node "^2.3.3"
 
 "@babel/plugin-transform-modules-commonjs@^7.9.6":


### PR DESCRIPTION
## Summary
Publish transpiled code under commonjs format so the library can be more plug and play.

<!--
**I acknowledge that any breaking changes will be highlighted in the following way**
```
- [BREAKING] Some fix I am making
```
-->

## Meta
- Packaged code will have better plug and play compatibility by being compiled down to commonjs format
